### PR TITLE
Rename Blueprint Repository to IDE

### DIFF
--- a/otterdog/eclipse-theia.jsonnet
+++ b/otterdog/eclipse-theia.jsonnet
@@ -221,7 +221,8 @@ orgs.newOrg('eclipse-theia') {
         orgs.newEnvironment('github-pages'),
       ],
     },
-    orgs.newRepo('theia-blueprint') {
+    orgs.newRepo('theia-ide') {
+      aliases: ['theia-blueprint'],
       allow_squash_merge: false,
       allow_update_branch: false,
       default_branch: "master",


### PR DESCRIPTION
We'd like to rename the blueprint repository to IDE to complete the rebranding we started some time ago.

I hope the changes made to the file are fine, although I couldn't test them. Documentation reference for renaming can be found here: https://otterdog.readthedocs.io/en/latest/userguide/renaming/#example-usage.

closes https://github.com/eclipse-theia/theia-blueprint/issues/339
