### PR TITLE
Remove Lint job from required status checks for theia repository

### DIFF
--- a/otterdog/eclipse-theia.jsonnet
+++ b/otterdog/eclipse-theia.jsonnet
@@ -253,9 +253,6 @@ orgs.newOrg('ecd.theia', 'eclipse-theia') {
         orgs.newBranchProtectionRule('master') {
           is_admin_enforced: true,
           required_approving_review_count: 1,
-          required_status_checks+: [
-            "Lint"
-          ],
         },
         orgs.newBranchProtectionRule('che-7.0.0') {
           required_approving_review_count: 1,


### PR DESCRIPTION
Our CI workflow now ignores documentation-only changes (e.g., pure *.md changes) to save CI resources.
Since Lint was a required status check, these skipped workflows caused GitHub to block merges even though no code was affected. As a current example, please see https://github.com/eclipse-theia/theia/pull/16501

This update removes the Lint job from the required status checks
The ECA check remains required, ensuring contributor compliance (see also in the Dashboard: https://otterdog.eclipse.org/projects/ecd.theia/repos/theia#branch-protection-rules).

I also had a look at the Otterdog documentation for this (https://otterdog.readthedocs.io/en/latest/reference/organization/repository/status-check/)) but couldn’t find a cleaner way to handle skipped workflows.
However, I'm happy to adjust this if there's a more elegant way to keep the skip behavior while still meeting branch protection requirements.

TIA!